### PR TITLE
Move to webshot2

### DIFF
--- a/src/sankey_charts.R
+++ b/src/sankey_charts.R
@@ -1,7 +1,7 @@
 library(dplyr)
 library(networkD3)
 library(htmlwidgets)
-library(webshot)
+library(webshot2)
 
 sankey_chart <- function(input_dir, output_dir, filter_date = "") {
 


### PR DESCRIPTION
Which relies on the maintained chromote rather than on webshot which uses the unmaintained phantomjs.

As per https://github.com/rstudio/webshot2:

webshot2 is meant to be a replacement for [webshot](https://wch.github.io/webshot/), except that instead of using PhantomJS, it uses headless Chrome via the [Chromote](https://github.com/rstudio/chromote) package.